### PR TITLE
Update 07.07.md - Missing instruction on including an import

### DIFF
--- a/topic-05-models/unit-2/book-playtime-0-5-0/07.07.md
+++ b/topic-05-models/unit-2/book-playtime-0-5-0/07.07.md
@@ -164,12 +164,13 @@ These failures relate to the extra data returned from mongo:
 
 ![](img/13.png)
 
-These are the revised assertions :
+These are the revised assertions : (missing instruction to include "import { assertSubset } from "./test-utils.js";" in playlist-model-test.js unless I have missed this previously.)
 
 ~~~javascript
     // assert.equal(mozart, playlist);    
     assertSubset(mozart, playlist);
 ~~~
+
 
 Change the occurrences of the above in PlaylistModel tests and rerun:
 


### PR DESCRIPTION
Instruction on importing the assertSubset into playlist-model-test.js