### PR TITLE
Update 06.06.md

### DIFF
--- a/topic-04-tdd/unit-2/book-playtime-0-4-0/06.06.md
+++ b/topic-04-tdd/unit-2/book-playtime-0-4-0/06.06.md
@@ -30,6 +30,10 @@ Now try this one:
 
 ~~~javascript
   test("delete One User - fail", async () => {
+    for (let i = 0; i < testUsers.length; i += 1) {
+          // eslint-disable-next-line no-await-in-loop
+          await db.userStore.addUser(testUsers[i]);
+        }
     await db.userStore.deleteUserById("bad-id");
     const allUsers = await db.userStore.getAllUsers();
     assert.equal(testUsers.length, allUsers.length);


### PR DESCRIPTION
for the "delete One User - fail" test, we were trying to remove a user from an empty database...I think it makes more sense to add the test users first before we try a delete. The same error occurs where -1 is returned and the last user is deleted.