### PR TITLE
Fix playlist-controller.js addTrack fail action

### DIFF
--- a/prj/playtime/playtime-0.8.0/src/controllers/playlist-controller.js
+++ b/prj/playtime/playtime-0.8.0/src/controllers/playlist-controller.js
@@ -17,8 +17,9 @@ export const playlistController = {
     validate: {
       payload: TrackSpec,
       options: { abortEarly: false },
-      failAction: function (request, h, error) {
-        return h.view("playlist-view", { title: "Add track error", errors: error.details }).takeover().code(400);
+      failAction: async function (request, h, error) {
+        const playlist = await db.playlistStore.getPlaylistById(request.params.id);
+        return h.view("playlist-view", { title: "Add track error", playlist: playlist, errors: error.details }).takeover().code(400);
       },
     },
     handler: async function (request, h) {


### PR DESCRIPTION
Ensure that the failAction in addTrack is also passed the relevant playlist object. 

This ensures that if the user submits a track that fails the validation once, the playlist is available in the context once return h.view("playlist-view") executes.

Currently, submitting a track that fails validation renders the view without passing in the playlist, which means that attempting to submit a playlist that is valid and will pass validation results in a 404, because the redirect does not have access to playlist._id.

This is not immediately clear, because h.view does not change the URL in the address bar, so it may appear the playlist id param is still provided. 

To verify this occurs, add a track successfully to a playlist, then try to add ones that fails and notice the track disappear, even though the URL still suggests we are still on the page for the original playlist, the playlist ID param is missing, e.g. `/playlist//addtrack'.