### PR TITLE
Ensure error context is passed to Boom in playlist-api.js

### DIFF
--- a/prj/playtime/playtime-0.8.0/src/api/playlist-api.js
+++ b/prj/playtime/playtime-0.8.0/src/api/playlist-api.js
@@ -10,7 +10,7 @@ export const playlistApi = {
         const playlists = await db.playlistStore.getAllPlaylists();
         return playlists;
       } catch (err) {
-        return Boom.serverUnavailable("Database Error");
+        return Boom.serverUnavailable("Database Error:", err);
       }
     },
   },
@@ -25,7 +25,7 @@ export const playlistApi = {
         }
         return playlist;
       } catch (err) {
-        return Boom.serverUnavailable("No Playlist with this id");
+        return Boom.serverUnavailable("No Playlist with this id:", err);
       }
     },
   },
@@ -41,7 +41,7 @@ export const playlistApi = {
         }
         return Boom.badImplementation("error creating playlist");
       } catch (err) {
-        return Boom.serverUnavailable("Database Error");
+        return Boom.serverUnavailable("Database Error:", err);
       }
     },
   },
@@ -57,7 +57,7 @@ export const playlistApi = {
         await db.playlistStore.deletePlaylistById(playlist._id);
         return h.response().code(204);
       } catch (err) {
-        return Boom.serverUnavailable("No Playlist with this id");
+        return Boom.serverUnavailable("No Playlist with this id:", err);
       }
     },
   },
@@ -69,7 +69,7 @@ export const playlistApi = {
         await db.playlistStore.deleteAllPlaylists();
         return h.response().code(204);
       } catch (err) {
-        return Boom.serverUnavailable("Database Error");
+        return Boom.serverUnavailable("Database Error:", err);
       }
     },
   },


### PR DESCRIPTION
Adds the content of the 'err' variable in the catch block to the Boom messages to provide extra context about what failed.

Currently it can be hard to debug basic things, like knowing if a method was called with a wrong name, as only default messages like "Database Error" are passed.

Requires further one further PR to be merged to ensure tests still pass.