### PR TITLE
Ensure tests in playlist-api-test.js pass if 'err' value passed to Boom

### DIFF
--- a/prj/playtime/playtime-0.8.0/test/api/playlist-api-test.js
+++ b/prj/playtime/playtime-0.8.0/test/api/playlist-api-test.js
@@ -32,7 +32,7 @@ suite("Playlist API tests", () => {
       const returnedPlaylist = await playtimeService.getPlaylist(playlist.id);
       assert.fail("Should not return a response");
     } catch (error) {
-      assert(error.response.data.message === "No Playlist with this id", "Incorrect Response Message");
+      assert(error.response.data.message.startsWith("No Playlist with this id"), "Incorrect Response Message");
     }
   });
 
@@ -54,7 +54,7 @@ suite("Playlist API tests", () => {
       const response = await playtimeService.deletePlaylist("not an id");
       assert.fail("Should not return a response");
     } catch (error) {
-      assert(error.response.data.message === "No Playlist with this id", "Incorrect Response Message");
+      assert(error.response.data.message.startsWith("No Playlist with this id"), "Incorrect Response Message");
     }
   });
 });


### PR DESCRIPTION
Ensures that the tests still work as expected if we add the actual error messages generated by the try catch blocks in playlist-api (along with the expected static error messages). Uses .startsWith instead of ===.

Requires changes made (passing 'err' to Boom) in #25.