### PR TITLE
Ensure that users-api-test.js still passes if we pass 'err' contexts to Boom.

### DIFF
--- a/prj/playtime/playtime-0.8.0/test/api/users-api-test.js
+++ b/prj/playtime/playtime-0.8.0/test/api/users-api-test.js
@@ -38,7 +38,7 @@ suite("User API tests", () => {
       const returnedUser = await playtimeService.getUser("1234");
       assert.fail("Should not return a response");
     } catch (error) {
-      assert(error.response.data.message === "No User with this id");
+      assert(error.response.data.message.startsWith("No User with this id"));
       // assert.equal(error.response.data.statusCode, 503);
     }
   });


### PR DESCRIPTION
Ensures that the tests will still pass even if we append the static error message with the actual error generated in the try catch block of user-api.js (just uses .startsWith instead of ===).

Requires the changes to user API implemented by #28.