### PR TITLE
Update Chrome Extension

### DIFF
--- a/unit-1-node/topic-01-node/unit-2/book-playtime-0-1-0/03.03.md
+++ b/unit-1-node/topic-01-node/unit-2/book-playtime-0-1-0/03.03.md
@@ -106,5 +106,8 @@ Browsing to the app we should see:
 
 In the above, we are using a Chrome plugin called `JSONViewer` - which will display JSON responses formatted as above. It will not be invoked if the responses are HTML.
 
-- [JSONViewer](https://chrome.google.com/webstore/detail/json-viewer/gbmdgpbipfallnflgajpaliibnhdgobh)
+<!---
+Chrome extension no longer available - providing alternative link
+--->
+- [JSONViewerPro](https://chromewebstore.google.com/detail/json-viewer-pro/eifflpmocdbdmepbjaopkkhbfmdgijcc)
 


### PR DESCRIPTION
JSON Viewer Extension is no longer available - added an alternative option and included the updated link. Comment indicates which section.