### PR TITLE
Fix document title in 01.01.md

### DIFF
--- a/unit-4-svelte/topic-15-svelte-components/side-unit/book-0-svelte-2-todo/01.01.md
+++ b/unit-4-svelte/topic-15-svelte-components/side-unit/book-0-svelte-2-todo/01.01.md
@@ -13,7 +13,7 @@ Create a new file in `lib` called `Title.svelte`
 
 In routes/+page.svelte, import the component in the `<script>` section:
 
-### routes/App.svelte
+### routes/+page.svelte
 
 ~~~javascript
   import Title from "$lib/Title.svelte";


### PR DESCRIPTION
The tutorial talks about routes/+page.svelte, but then gives a code snippet for routes/App.svelte, which doesn't seem to exist - though src/app.html does. So maybe this code snippet was meant to be routes/+page.svelete too?