### PR TITLE
Fix typo in 04.04.md

### DIFF
--- a/unit-4-svelte/topic-15-svelte-components/side-unit/book-0-svelte-2-todo/04.04.md
+++ b/unit-4-svelte/topic-15-svelte-components/side-unit/book-0-svelte-2-todo/04.04.md
@@ -6,7 +6,7 @@ Introduce this new component:
 
 ~~~html
 <script>
-  let { addTodo, todoText = } = $props();
+  let { addTodo, todoText } = $props();
 </script>
 
 <div class="section box">


### PR DESCRIPTION
Looks like there was an extra '=' here - gave me syntax highlighting warnings.